### PR TITLE
Add the makecomplex pixfun that makes a complex out of two bands

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -26,6 +26,8 @@ List of pixel functions
 :"imag":
     extract imaginary part from a single raster band (0 for
     non-complex)
+:"makecomplex":
+    make a complex band merging two bands used as real and imag values
 :"mod":
     extract module from a single raster band (real or complex)
 :"phase":

--- a/autotest/gcore/data/pixfun_makecomplex.vrt
+++ b/autotest/gcore/data/pixfun_makecomplex.vrt
@@ -1,0 +1,19 @@
+<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="CFloat32" band="1" subClass="VRTDerivedRasterBand">
+    <Description>Make complex</Description>
+    <PixelFunctionType>makecomplex</PixelFunctionType>
+    <SourceTransferType>CFloat32</SourceTransferType>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">int32.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">int32.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -136,6 +136,31 @@ def pixfun_imag_r():
 
 
 ###############################################################################
+# Verify imaginary part extraction from a real dataset.
+
+def pixfun_makecomplex():
+
+    filename = 'data/pixfun_makecomplex.vrt'
+    ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
+    if ds is None:
+        gdaltest.post_reason('Unable to open "%s" dataset.' % filename)
+        return 'fail'
+    data = ds.GetRasterBand(1).ReadAsArray()
+
+    reffilename = 'data/int32.tif'
+    refds = gdal.Open(reffilename)
+    if refds is None:
+        gdaltest.post_reason('Unable to open "%s" dataset.' % reffilename)
+        return 'fail'
+    refdata = refds.GetRasterBand(1).ReadAsArray()
+
+    if not numpy.allclose(data, refdata + 1j * refdata):
+        return 'fail'
+
+    return 'success'
+
+
+###############################################################################
 # Verify modulus extraction from a complex (float) dataset.
 
 def pixfun_mod_c():
@@ -731,6 +756,7 @@ gdaltest_list = [
     pixfun_real_r,
     pixfun_imag_c,
     pixfun_imag_r,
+    pixfun_makecomplex,
     pixfun_mod_c,
     pixfun_mod_r,
     pixfun_phase_c,


### PR DESCRIPTION
I added a "makecomplex" pixel function that builds a single complex band out of a real and an imag band, as found for example in the CSK SLC SAR data.

The PR includes tests and docs.
